### PR TITLE
Dark theme

### DIFF
--- a/JinoDiaryApp/ContentView.swift
+++ b/JinoDiaryApp/ContentView.swift
@@ -162,7 +162,8 @@ struct ContentView: View {
                                 saveTextForDate()
                             }
                             .lineSpacing(10)
-                            .background(Color.white)
+                            .colorScheme(.dark)
+                            .background(Color.black.opacity(0.87))
                     }
                     .clipShape(RoundedRectangle(cornerRadius: 10))
 


### PR DESCRIPTION
It has only 1 commit now, for setting a dark theme for the TextEditor but maybe if decided, this could be used to fully implement dark-theme for the app.

An idea is to add a toggle somewhere, to change between light and dark theme.

And of course, what's left after, is to set a color for dark-theme for every other piece of UI. The TextEditor is the only one in this PR.